### PR TITLE
scripts: allow overwrite ssm parameter

### DIFF
--- a/scripts/put-ssm.sh
+++ b/scripts/put-ssm.sh
@@ -10,4 +10,5 @@ read -sp "API Key (not eched to terminal): " passwd; echo
 aws ssm --region ${3} \
     put-parameter --name ${1} \
     --description "Used by stack: ${2}" \
+    --overwrite \
     --value ${passwd} --type SecureString


### PR DESCRIPTION
It's nice to be able to use the `make put*` commands to update parameters after they've been set the first time.