### PR TITLE
lambda: set slack \@handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ employees to build and present projects or ideas that fulfill some kind of need
 at the company.
 
 ## How to Deploy
-1. Create an Integrated Bot that you can invite to your channel. https://my.slack.com/services/new/bot
+1. Create an App that you can invite to your channel.
+  - Go to [Slack Apps](https://api.slack.com/apps) and click "Create New App"
+  - Set App Name and Development Slack Workspace
+  - Add OAuth scopes: `channels.manage`, `channels:read`, `groups:read`,
+    `im:write`, `mpim:read`, `users:read`, `users:read.email`
+  - Install App to Workspace
+  - Invite App to channel where you want topic updated
 2. Obtain a PagerDuty API Key (v2) [Directions Here](https://support.pagerduty.com/docs/using-the-api#section-generating-an-api-key)
 3. Deploy CloudFormation
   - Clone repo

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -90,7 +90,7 @@ def get_slack_at_user(email):
     payload['email'] = email
     try:
         r = requests.get('https://slack.com/api/users.lookupByEmail', payload)
-        username = r.json()['user']['name']
+        username = r.json()['user']['id']
         logger.debug("Next Slack username: {}".format(username))
         return '<@%s>' % username
     except KeyError:

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -310,7 +310,7 @@ def do_work_critical(obj):
     )
 
     for channel in config['chat_provider']['channels']:
-        update_chat_channel(config['chat_provider']['name'], config['chat_provider']['channels'], topic)
+        update_chat_channel(config['chat_provider']['name'], channel, topic)
 
 
 def handler(event, context):


### PR DESCRIPTION
It's nice to be able to set @- handle in Slack topic because it allows
person to be notified by Slack when they go oncall, and because other
people can click that handle to go to DM or get info about the oncall
person.

This commit makes this the new behavior in lambda/main.py. Because this
behavior requires getting Slack user from the Slack API, and because Bot
users don't have that permission, this commit also updates README.md
with instructions on creating an App user with sufficient permissions.