### PR TITLE
Requests deprecation: use unaffected runtime

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.8
       Timeout: 120
       CodeUri:
         Bucket: !Ref Bucket


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/

Vendored requests is being removed from the Python 3.6 runtime on Jan
31. The Python 3.8 runtime is unaffected.

Other ways to address this deprecation would be to replace requests
usage with urllib3 usage, or to add a dependency on a lambda layer which
provides requests.