### PR TITLE
Pin lambda layer so requests keeps working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 STACKNAME_BASE=pagerduty-oncall-chat-topic
+# if REGION is changed, use table in https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/ to update ChatTopicFunction lambda layer value
 REGION="ca-central-1"
 # Bucket in REGION that is used for deployment (`pd-oncall-chat-topic` is already used)
 BUCKET=$(STACKNAME_BASE)

--- a/deployment.yml
+++ b/deployment.yml
@@ -95,6 +95,8 @@ Resources:
       CodeUri:
         Bucket: !Ref Bucket
         Key: !Ref md5
+      Layers:
+        - arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:4 # for ca-central-1 region
       Environment:
         Variables:
           PD_API_KEY_NAME: !Ref PDSSMKeyName

--- a/deployment.yml
+++ b/deployment.yml
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.8
       Timeout: 120
       CodeUri:
         Bucket: !Ref Bucket


### PR DESCRIPTION
per https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/ for the layer version and https://aws.amazon.com/blogs/compute/working-with-aws-lambda-and-lambda-layers-in-aws-sam/ for pinning lambda layers in Serverless, I think this should work? Interested in any institutional knowledge we might have on hand about how to test this other than landing and watching whether it breaks. 