### PR TITLE
Sec 4219 multiple oncall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ at the company.
     commands should work unless modified elsewhere (advanced config).
   - `make put-pd-key`
   - `make put-slack-key`
-5. Write Config to DynomoDB for which channels to update.
+5. Write Config to DynamoDB for which channels to update.
   - It is possible to use the AWS CLI for this (or finish
     [#4](https://github.com/PagerDuty/pd-oncall-chat-topic/issues/4) for ease of
     use)
@@ -52,7 +52,7 @@ at the company.
 
 ## Architecture
 The main part of this infrastructure is an AWS Lambda Function that operates on
-a schedule (cron), reads configuration information from an DynomoDB Table and
+a schedule (cron), reads configuration information from an DynamoDB Table and
 secrets from AWS EC2 Parameter Store. This is all deployed from a AWS
 CloudFormation template.
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ at the company.
   }
   ```
   (where `schedule` is the PagerDuty Schedule ID, and `slack` is the Slack
-  Channel ID. You can have a space-separated list of channels. `sched_name` is
-  optional and if omitted will be looked up)
+  Channel ID. You can have a space-separated list of channels. `sched_name` is optional and if omitted will be looked up)
+  If you have a split on-call rotation, you may places multiple schedules and schedule names separated by whitespace.
+  
 
 ## Architecture
 The main part of this infrastructure is an AWS Lambda Function that operates on

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from operator import indexOf
 import os
 from datetime import datetime, timezone, timedelta
 import threading
@@ -199,7 +198,7 @@ def do_work(obj):
             return 127
         try:
             sched_names = (obj['sched_name']['S']).split()
-            sched_name = sched_names[schedules.index(schedule)]
+            sched_name = sched_names[schedules.index(schedule)] #We want the schedule name in the same position as the schedule we're using
         except:
             sched_name = get_pd_schedule_name(schedule)
         oncall_dict[username] = sched_name

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -187,8 +187,9 @@ def do_work(obj):
     logger.debug("Operating on {}".format(obj))
     # schedule will ALWAYS be there, it is a ddb primarykey
     schedules = obj['schedule']['S']
+    schedule_list = schedules.split()
     oncall_dict = {}
-    for schedule in schedules.split():  #schedule can now be a whitespace separated 'list' in a string
+    for schedule in schedule_list:  #schedule can now be a whitespace separated 'list' in a string
         schedule = figure_out_schedule(schedule)
 
         if schedule:
@@ -198,7 +199,7 @@ def do_work(obj):
             return 127
         try:
             sched_names = (obj['sched_name']['S']).split()
-            sched_name = sched_names[schedules.index(schedule)] #We want the schedule name in the same position as the schedule we're using
+            sched_name = sched_names[schedule_list.index(schedule)] #We want the schedule name in the same position as the schedule we're using
         except:
             sched_name = get_pd_schedule_name(schedule)
         oncall_dict[username] = sched_name
@@ -213,15 +214,16 @@ def do_work(obj):
                 user,
                 oncall_dict[user]
             )
-            if 'slack' in obj.keys():
-                slack = obj['slack']['S']
-                # 'slack' may contain multiple channels seperated by whitespace
-                for channel in slack.split():
-                    update_slack_topic(channel, topic)
-            elif 'hipchat' in obj.keys():
-                # hipchat = obj['hipchat']['S']
-                logger.critical("HipChat is not supported yet. Ignoring this entry...")
             i += 1
+            
+        if 'slack' in obj.keys():
+            slack = obj['slack']['S']
+            # 'slack' may contain multiple channels seperated by whitespace
+            for channel in slack.split():
+                update_slack_topic(channel, topic)
+        elif 'hipchat' in obj.keys():
+            # hipchat = obj['hipchat']['S']
+            logger.critical("HipChat is not supported yet. Ignoring this entry...")
     sema.release()
 
 


### PR DESCRIPTION
Security has moved to a split on-call rotation.  We'd like to publish both rotations in a single channel, i.e. pull two different PagerDuty schedules and display them both.