### PR TITLE
changed list split delimiter to commas for schedule and schedule name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ at the company.
   ```
   (where `schedule` is the PagerDuty Schedule ID, and `slack` is the Slack
   Channel ID. You can have a space-separated list of channels. `sched_name` is optional and if omitted will be looked up)
-  If you have a split on-call rotation, you may places multiple schedules and schedule names separated by whitespace.
+  If you have a split on-call rotation, you may place multiple comma-separated schedules and schedule names.
   
 
 ## Architecture

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -187,7 +187,7 @@ def do_work(obj):
     logger.debug("Operating on {}".format(obj))
     # schedule will ALWAYS be there, it is a ddb primarykey
     schedules = obj['schedule']['S']
-    schedule_list = schedules.split()
+    schedule_list = schedules.split(',')
     oncall_dict = {}
     for schedule in schedule_list:  #schedule can now be a whitespace separated 'list' in a string
         schedule = figure_out_schedule(schedule)
@@ -198,7 +198,7 @@ def do_work(obj):
             logger.critical("Exiting: Schedule not found or not valid, see previous errors")
             return 127
         try:
-            sched_names = (obj['sched_name']['S']).split()
+            sched_names = (obj['sched_name']['S']).split(',')
             sched_name = sched_names[schedule_list.index(schedule)] #We want the schedule name in the same position as the schedule we're using
         except:
             sched_name = get_pd_schedule_name(schedule)


### PR DESCRIPTION
Realized that some teams have spaces in their Schedule names, which can cause splitting issues when splitting by whitespace.  Changed logic to split on commas instead.