### PR TITLE
replace 2x call with a single call to schedules

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -46,7 +46,7 @@ def get_user(schedule_id):
         logger.critical("ABORT: Not a valid schedule: {}".format(schedule_id))
         return False
     try:
-        username = schedule.json()['final_schedule']['rendered_schedule_entries'][0]['users']['summary']
+        username = schedule.json()['final_schedule']['rendered_schedule_entries'][0]['user']['summary']
         # Check if the current user is on-call due to an override
         if schedule.json()['overrides_subschedule']['rendered_schedule_entries']:  # is not empty list
             username = username + " (Override)"


### PR DESCRIPTION
## Example of error
![Screen Shot 2022-10-17 at 2 04 07 PM](https://user-images.githubusercontent.com/2512676/196282966-8b80f5e4-4819-4fec-9f0c-bff24bad5bba.png)

## Reference Schedule
![Screen Shot 2022-10-17 at 2 04 22 PM](https://user-images.githubusercontent.com/2512676/196283016-a79c756c-d1ea-41e3-9b85-689634e88a85.png)

## Another example
![Screen Shot 2022-10-17 at 2 12 14 PM](https://user-images.githubusercontent.com/2512676/196284377-734170ba-c827-45ee-b95c-18b3f407cac2.png)

## Schedule at that time
![Screen Shot 2022-10-17 at 2 12 43 PM](https://user-images.githubusercontent.com/2512676/196284461-6f630cd2-1773-4d3f-b8eb-7dc80a5fb0ae.png)


## Explanation

In both cases above we have someone listed as on-call as an override despite not overriding the schedule. This causes a duplicate entry since on the next run the on-call will "change" from the incorrect override to the current on-call's shift. Sidenote, if someone has an override that borders a regular shift we merge them and consider it one shift. This is true for all bordering shifts for the same user.

While calling `/schedules/${id}/users` and `/schedules/${id}/overrides` should return the same user, a user and an empty array, or 2 empty arrays, my guess is the `/overrides` endpoint is returning slightly stale data while the `/users` endpoint is returning correctly. In this case, we used to append even though the current user was not on-call due to an override. By consolidating our requests we should have fewer double messages and either update the channel once, correctly or not update the channel because the latest data isn't there yet. The latter case will be resolved when the endpoint is polled again and for our use case +/- 5 minutes is not a problem (and is within our DB replication window).

