### PR TITLE
Fix detection of whether to update topic when schedule ends in whitespace

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -144,6 +144,7 @@ def update_slack_topic(channel, proposed_update):
         first_part = "none"
         second_part = "."  # if there is no topic, just add something
 
+    proposed_update = proposed_update.strip()
     if proposed_update != first_part:
         # slack limits topic to 250 chars
         topic = "{} | {}".format(proposed_update, second_part)
@@ -215,7 +216,7 @@ def do_work(obj):
                 oncall_dict[user]
             )
             i += 1
-            
+
         if 'slack' in obj.keys():
             slack = obj['slack']['S']
             # 'slack' may contain multiple channels seperated by whitespace


### PR DESCRIPTION
# Context
When  a schedule name has whitespace at the end, the detection for whether to update the topic or not was broken, and pd-oncall-chat-topic would always detect that it should prepend the oncall topic to whatever was there. So we would end up with on-call topics that looked like this:
<img width="1096" alt="Screen Shot 2023-04-20 at 15 46 30" src="https://user-images.githubusercontent.com/12139316/233472283-e9dd2838-9724-4ce1-bdbc-68f5edf460f0.png">

# this change

this change strips the whitespace from the on call schedule name prior to comparing it with the current topic name (which also has a strip() a few lines up). Thus both old and proposed topics undergo a whitespace trimming, making the comparison more meaningful.

# Testing

I tested this internally with a schedule having whitespace and it seems to work.