### PR TITLE
SDV-2962: make lambda script python 3.12 compatible 

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -7,13 +7,13 @@ import logging
 import re
 
 import json
-import urllib3
+from urllib3 import PoolManager
 import boto3
 
 # semaphore limit of 5, picked this number arbitrarily
 maxthreads = 5
 sema = threading.Semaphore(value=maxthreads)
-http = urllib3.PoolManager()
+http = PoolManager()
 
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -46,7 +46,7 @@ def get_user(schedule_id):
     payload = {}
     payload['since'] = since.isoformat()
     payload['until'] = now.isoformat()
-    response = http.request('GET', normal_url, headers=headers, params=payload)
+    response = http.request('GET', normal_url, headers=headers, fields=payload)
     body = response.data.decode('utf-8')
     normal = json.loads(body)
     if normal.status_code == 404:
@@ -59,7 +59,7 @@ def get_user(schedule_id):
         # over the normal schedule. The problem must be approached this way
         # because the /overrides endpoint does not guarentee an order of the
         # output.
-        override_response = http.request('GET', override_url, headers=headers, params=payload)
+        override_response = http.request('GET', override_url, headers=headers, fields=payload)
         body = override_response.data.decode('utf-8')
         override = json.loads(body)
         if override.json()['overrides']:  # is not empty list
@@ -186,7 +186,7 @@ def figure_out_schedule(s):
     payload = {}
     payload['query'] = s
     # If there is no override, then check the schedule directly
-    response = http.request('GET', url, headers=headers, params=payload)
+    response = http.request('GET', url, headers=headers, fields=payload)
     body = response.data.decode('utf-8')
     r = json.loads(body)
     try:

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -48,12 +48,12 @@ def get_user(schedule_id):
     payload['until'] = now.isoformat()
     response = http.request('GET', normal_url, headers=headers, fields=payload)
     body = response.data.decode('utf-8')
-    normal = json.loads(body)
-    if normal.status_code == 404:
+    if response.status == 404:
         logger.critical("ABORT: Not a valid schedule: {}".format(schedule_id))
         return False
+    normal = json.loads(body)
     try:
-        username = normal.json()['users'][0]['name']
+        username = normal['users'][0]['name']
         # Check for overrides
         # If there is *any* override, then the above username is an override
         # over the normal schedule. The problem must be approached this way
@@ -84,10 +84,10 @@ def get_pd_schedule_name(schedule_id):
     body = response.data.decode('utf-8')
     r = json.loads(body)
     try:
-        return r.json()['schedule']['name']
+        return r.['schedule']['name']
     except KeyError:
-        logger.debug(r.status_code)
-        logger.debug(r.json())
+        logger.debug(response.status)
+        logger.debug(r)
         return None
 
 

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -6,7 +6,7 @@ import threading
 import logging
 import re
 
-from botocore.vendored import requests
+import requests
 import boto3
 
 # semaphore limit of 5, picked this number arbitrarily

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -98,7 +98,7 @@ def get_slack_topic(channel):
         WithDecryption=True)['Parameters'][0]['Value']
     payload['channel'] = channel
     try:
-        response = http.request('POST', 'https://slack.com/api/conversations.info', data=payload)
+        response = http.request('POST', 'https://slack.com/api/conversations.info', fields=payload)
         body = response.data.decode('utf-8')
         r = json.loads(body)
         current = r.json()['channel']['topic']['value']
@@ -163,7 +163,7 @@ def update_slack_topic(channel, proposed_update):
         if len(topic) > 250:
             topic = topic[0:247] + "..."
         payload['topic'] = topic
-        response = http.request('POST', 'https://slack.com/api/conversations.setTopic', data=payload)
+        response = http.request('POST', 'https://slack.com/api/conversations.setTopic', fields=payload)
         body = response.data.decode('utf-8')
         r = json.loads(body)
         logger.debug("Response for '{}' was: {}".format(channel, r.json()))

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -84,7 +84,7 @@ def get_pd_schedule_name(schedule_id):
     body = response.data.decode('utf-8')
     r = json.loads(body)
     try:
-        return r.['schedule']['name']
+        return r['schedule']['name']
     except KeyError:
         logger.debug(response.status)
         logger.debug(r)

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -62,12 +62,12 @@ def get_user(schedule_id):
         override_response = http.request('GET', override_url, headers=headers, fields=payload)
         body = override_response.data.decode('utf-8')
         override = json.loads(body)
-        if override.json()['overrides']:  # is not empty list
+        if override['overrides']:  # is not empty list
             username = username + " (Override)"
     except IndexError:
         username = "No One :thisisfine:"
     except KeyError:
-        username = f"Deactivated User :scream: ({normal.json()['users'][0]['summary']})"
+        username = f"Deactivated User :scream: ({normal['users'][0]['summary']})"
 
     logger.info("Currently on call: {}".format(username))
     return username
@@ -101,7 +101,7 @@ def get_slack_topic(channel):
         response = http.request('POST', 'https://slack.com/api/conversations.info', fields=payload)
         body = response.data.decode('utf-8')
         r = json.loads(body)
-        current = r.json()['channel']['topic']['value']
+        current = r['channel']['topic']['value']
         logger.debug("Current Topic: '{}'".format(current))
     except KeyError:
         logger.critical("Could not find '{}' on slack, has the on-call bot been removed from this channel?".format(channel))
@@ -166,7 +166,7 @@ def update_slack_topic(channel, proposed_update):
         response = http.request('POST', 'https://slack.com/api/conversations.setTopic', fields=payload)
         body = response.data.decode('utf-8')
         r = json.loads(body)
-        logger.debug("Response for '{}' was: {}".format(channel, r.json()))
+        logger.debug("Response for '{}' was: {}".format(channel, r))
     else:
         logger.info("Not updating slack, topic is the same")
         return None
@@ -191,7 +191,7 @@ def figure_out_schedule(s):
     r = json.loads(body)
     try:
         # This is fragile. fuzzy search may not do what you want
-        sid = r.json()['schedules'][0]['id']
+        sid = r['schedules'][0]['id']
     except IndexError:
         logger.debug("Schedule Not Found for: {}".format(s))
         sid = None


### PR DESCRIPTION
* We are upgrading python runtimes and must use `urllib3` instead of `botocore.vendored` 
* See this [PR](https://github.com/PagerDuty/pd-oncall-chat-topic-infra/pull/143#issue-2303670433) (which uses this branch) for testing details