### PR TITLE
[MOZA-3554] Fix override label precise to the minute

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -26,6 +26,10 @@ PD_API_KEY = boto3.client('ssm').get_parameters(
     WithDecryption=True)['Parameters'][0]['Value']
 
 
+def parse_dt(s):
+    return datetime.fromisoformat(s.replace('Z', '+00:00'))
+
+
 # Get the Current User on-call for a given schedule
 def get_user(schedule_id):
     global PD_API_KEY
@@ -58,10 +62,9 @@ def get_user(schedule_id):
         override_response = http.request('GET', override_url, headers=headers, fields=payload)
         body = override_response.data.decode('utf-8')
         override = json.loads(body)
-        now_iso = now.isoformat()
         active_overrides = [
             o for o in override['overrides']
-            if o['start'] <= now_iso < o['end']
+            if parse_dt(o['start']) <= now < parse_dt(o['end'])
         ]
         if active_overrides:
             username = username + " (Override)"

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -54,15 +54,16 @@ def get_user(schedule_id):
     normal = json.loads(body)
     try:
         username = normal['users'][0]['name']
-        # Check for overrides
-        # If there is *any* override, then the above username is an override
-        # over the normal schedule. The problem must be approached this way
-        # because the /overrides endpoint does not guarentee an order of the
-        # output.
+        # Check for overrides active at the current moment
         override_response = http.request('GET', override_url, headers=headers, fields=payload)
         body = override_response.data.decode('utf-8')
         override = json.loads(body)
-        if override['overrides']:  # is not empty list
+        now_iso = now.isoformat()
+        active_overrides = [
+            o for o in override['overrides']
+            if o['start'] <= now_iso < o['end']
+        ]
+        if active_overrides:
             username = username + " (Override)"
     except IndexError:
         username = "No One :thisisfine:"

--- a/lambda/test_main.py
+++ b/lambda/test_main.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+# Set required env vars before importing main (read at module level)
+os.environ.setdefault('PD_API_KEY_NAME', 'fake-pd-key')
+
+# Stub boto3 and urllib3 before importing main to prevent module-level side effects
+_boto3_stub = MagicMock()
+_boto3_stub.client.return_value.get_parameters.return_value = {
+    'Parameters': [{'Value': 'fake-api-key'}]
+}
+sys.modules.setdefault('boto3', _boto3_stub)
+sys.modules.setdefault('urllib3', MagicMock())
+
+import main  # noqa: E402
+
+
+def _resp(data, status=200):
+    m = MagicMock()
+    m.data = json.dumps(data).encode()
+    m.status = status
+    return m
+
+
+NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestGetUser(unittest.TestCase):
+
+    SCHEDULE_ID = 'PABC123'
+
+    def test_returns_no_one_when_schedule_is_empty(self):
+        with patch('main.http') as mock_http, patch('main.datetime') as mock_dt:
+            mock_dt.now.return_value = NOW
+            mock_http.request.return_value = _resp({'users': []})
+            self.assertEqual(main.get_user(self.SCHEDULE_ID), 'No One :thisisfine:')
+
+    def test_returns_false_when_schedule_not_found(self):
+        with patch('main.http') as mock_http, patch('main.datetime') as mock_dt:
+            mock_dt.now.return_value = NOW
+            mock_http.request.return_value = _resp({}, status=404)
+            self.assertFalse(main.get_user(self.SCHEDULE_ID))
+
+    def test_returns_deactivated_label_for_user_without_name(self):
+        with patch('main.http') as mock_http, patch('main.datetime') as mock_dt:
+            mock_dt.now.return_value = NOW
+            mock_http.request.return_value = _resp({'users': [{'summary': 'Summary but no name'}]})
+            result = main.get_user(self.SCHEDULE_ID)
+        self.assertIn('Deactivated User :scream:', result)
+        self.assertIn('Summary but no name', result)
+
+    class OverrideLabel(unittest.TestCase):
+
+        SCHEDULE_ID = 'PABC123'
+
+        def _call(self, users, overrides, now=NOW):
+            with patch('main.http') as mock_http, patch('main.datetime') as mock_dt:
+                mock_dt.now.return_value = now
+                mock_http.request.side_effect = [
+                    _resp({'users': users}),
+                    _resp({'overrides': overrides}),
+                ]
+                return main.get_user(self.SCHEDULE_ID)
+
+        def test_no_label_when_no_overrides(self):
+            self.assertEqual(self._call([{'name': 'Alice'}], []), 'Alice')
+
+        def test_appends_label_when_override_is_active(self):
+            override = {'start': '2024-06-01T11:00:00+00:00', 'end': '2024-06-01T13:00:00+00:00'}
+            self.assertEqual(self._call([{'name': 'Bob'}], [override]), 'Bob (Override)')
+
+        def test_no_label_when_override_just_ended(self):
+            # end is exclusive: end == now means the override just finished
+            override = {'start': '2024-06-01T11:00:00+00:00', 'end': '2024-06-01T12:00:00+00:00'}
+            self.assertEqual(self._call([{'name': 'Carol'}], [override]), 'Carol')
+
+        def test_no_label_when_override_starts_in_future(self):
+            override = {'start': '2024-06-01T12:00:30+00:00', 'end': '2024-06-01T14:00:00+00:00'}
+            self.assertEqual(self._call([{'name': 'Dave'}], [override]), 'Dave')
+
+        def test_appends_label_when_one_of_many_overrides_is_active(self):
+            overrides = [
+                {'start': '2024-06-01T09:00:00+00:00', 'end': '2024-06-01T10:00:00+00:00'},  # ended
+                {'start': '2024-06-01T11:30:00+00:00', 'end': '2024-06-01T13:00:00+00:00'},  # active
+                {'start': '2024-06-01T13:00:00+00:00', 'end': '2024-06-01T14:00:00+00:00'},  # future
+            ]
+            self.assertEqual(self._call([{'name': 'Eve'}], overrides), 'Eve (Override)')
+
+        def test_no_label_when_all_overrides_expired(self):
+            overrides = [
+                {'start': '2024-06-01T09:00:00+00:00', 'end': '2024-06-01T10:00:00+00:00'},
+                {'start': '2024-06-01T10:00:00+00:00', 'end': '2024-06-01T11:00:00+00:00'},
+            ]
+            self.assertEqual(self._call([{'name': 'Frank'}], overrides), 'Frank')
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestSuite()
+    suite.addTests(tests)
+    suite.addTests(loader.loadTestsFromTestCase(TestGetUser.OverrideLabel))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/test_main.py
+++ b/lambda/test_main.py
@@ -60,6 +60,7 @@ class TestGetUser(unittest.TestCase):
         def _call(self, users, overrides, now=NOW):
             with patch('main.http') as mock_http, patch('main.datetime') as mock_dt:
                 mock_dt.now.return_value = now
+                mock_dt.fromisoformat.side_effect = datetime.fromisoformat
                 mock_http.request.side_effect = [
                     _resp({'users': users}),
                     _resp({'overrides': overrides}),
@@ -96,6 +97,15 @@ class TestGetUser(unittest.TestCase):
                 {'start': '2024-06-01T10:00:00+00:00', 'end': '2024-06-01T11:00:00+00:00'},
             ]
             self.assertEqual(self._call([{'name': 'Frank'}], overrides), 'Frank')
+
+        def test_appends_label_when_override_uses_zulu_timezone(self):
+            override = {'start': '2024-06-01T11:00:00Z', 'end': '2024-06-01T13:00:00Z'}
+            self.assertEqual(self._call([{'name': 'Grace'}], [override]), 'Grace (Override)')
+
+        def test_appends_label_when_override_uses_eastern_time(self):
+            # NOW is 12:00 UTC = 08:00 EDT; override runs 07:00–09:00 EDT
+            override = {'start': '2024-06-01T07:00:00-04:00', 'end': '2024-06-01T09:00:00-04:00'}
+            self.assertEqual(self._call([{'name': 'Heidi'}], [override]), 'Heidi (Override)')
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
[MOZA-3554](https://pagerduty.atlassian.net/browse/MOZA-3554)

The (Override) label was being applied whenever any override existed in a ±1 minute window, rather than only when an override is active at the current moment. This caused false positives when an override had just ended or was about to start.

Root cause: get_user() in lambda/main.py checked if override['overrides'] without filtering by time, so overrides that recently ended or hadn't started yet would incorrectly trigger the label.

Fix: Filter the override list to entries where start <= now < end before appending (Override) to the username.    

[MOZA-3554]: https://pagerduty.atlassian.net/browse/MOZA-3554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ